### PR TITLE
Feature/fix dodgy names in cluster files

### DIFF
--- a/bin/wideSCCluster2longSCCluster.R
+++ b/bin/wideSCCluster2longSCCluster.R
@@ -11,7 +11,7 @@ option_list <- list(
 
 opt <- parse_args(OptionParser(option_list=option_list))
 
-read.table(opt$clusters_path,header = TRUE) -> clusters_wide
+read.table(opt$clusters_path, header = TRUE, check.names = FALSE) -> clusters_wide
 gather(clusters_wide, key = "cell_id", value = "cluster_id", -sel.K, -K) -> clusters_long
 
 clusters_long$experiment_accession <- opt$exp_acc

--- a/bin/wideSCCluster2longSCCluster.R
+++ b/bin/wideSCCluster2longSCCluster.R
@@ -11,7 +11,7 @@ option_list <- list(
 
 opt <- parse_args(OptionParser(option_list=option_list))
 
-read.table(opt$clusters_path, header = TRUE, check.names = FALSE) -> clusters_wide
+read.delim(opt$clusters_path, header = TRUE, check.names = FALSE, sep = '\t') -> clusters_wide
 gather(clusters_wide, key = "cell_id", value = "cluster_id", -sel.K, -K) -> clusters_long
 
 clusters_long$experiment_accession <- opt$exp_acc

--- a/tests/create-test-matrix-market-files.R
+++ b/tests/create-test-matrix-market-files.R
@@ -68,5 +68,17 @@ query_result<-data.frame(experiment_accession=rep(exp_id,300),
 attach(query_result)
 write.table(query_result[order(gene_id, cell_id),], file=paste(exp_id,".query_expected.txt",sep=""), quote = FALSE, row.names = FALSE)
 
+# Create a test cluster matrix with weird column names
+test_clusters <- data.frame(sel.K=c('FALSE', 'FALSE', 'TRUE', 'FALSE', 'FALSE'), K = 2:6)
+weird_names <- c("realy--weird # # name one}", 'i am() probably ==== being a ][ bit silly', '! but we &&&& need to ||| make sure R leaves ~~~ <> variable names £££ alone')
+
+test_clusters[[weird_names[1]]] <- 1:5
+test_clusters[[weird_names[2]]] <- 1:5
+test_clusters[[weird_names[3]]] <- 1:5
+
+write.table(test_clusters, file=paste0(exp_id, ".clusters_weird_names.txt"), sep="\t", quote = FALSE)
+
+# Write the same weird names as dataframe content
+writeLines(weird_names, paste0(exp_id, ".weird_names.txt"))
 
 

--- a/tests/random-data-set.bats
+++ b/tests/random-data-set.bats
@@ -48,6 +48,19 @@
   [ "$status" -eq 0 ]
 }
 
+@test "Clusters: Check that wideSCCluster2longSCCluster.R is in the path" {
+  run which wideSCCluster2longSCCluster.R
+  echo "output = ${output}"
+  [ "$status" -eq 0 ]
+}
+
+@test "Clusters: Check that column names are not mangled by R" {
+  export EXP_ID=TEST-EXP1
+  wideSCCluster2longSCCluster.R -c $EXP_ID.clusters_weird_names.txt -e $EXP_ID -o clustersToLoad.test.$EXP_ID.csv
+  run diff <(tail -n +2 clustersToLoad.test.$EXP_ID.csv | awk -F "\"*,\"*" '{print $2}' | uniq | sort) <(sort $EXP_ID.weird_names.txt) > /dev/null
+  [ "$status" -eq 0 ]
+}
+
 @test "Analytics: Reload dataset 1" {
   export EXP_ID=TEST-EXP1
   run load_db_scxa_analytics.sh


### PR DESCRIPTION
This PR tweaks the parsing of cluster files from iRAP to make sure column names don't get 'checked' and thereby mangled. Column names must not be changed, or the file falls out of sync with expression and t-SNE files and we get '0 cluster' issues on the front end. 

There is also a new test which tests that slightly silly column names don't get changed in bin/wideSCCluster2longSCCluster.R.