### PR TITLE
Hotfix: Moves bash installation from tests to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.8
 
-RUN apk update && apk add postgresql-client=10.5-r0 R=3.5.0-r1
+RUN apk update && apk add postgresql-client=10.5-r0 R=3.5.0-r1 bash
 RUN apk update && apk add --virtual build-dependencies \
     build-base gcc wget R-dev && \
     R -e "install.packages(c('optparse','tidyr','Matrix'), repos='https://cloud.r-project.org/')" && \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Module for Single Cell Expression Atlas database loading (v0.2.0)  
+# Module for Single Cell Expression Atlas database loading (v0.2.1)  
 
-An AtlasProd module for loading scxa-* tables data to postgres 10. Release v0.2.0
+An AtlasProd module for loading scxa-* tables data to postgres 10. Release v0.2.1
 was used for the September 2018 Data release of Singe Cell Expression Atlas.
 
 # `scxa_analytics` Table

--- a/tests/run_tests_inside_container.sh
+++ b/tests/run_tests_inside_container.sh
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env bash
+# Above ^^ will test that bash is installed
 
-apk add bash bats
+apk add bats
 
 /usr/local/tests/run_tests.sh


### PR DESCRIPTION
This fixes a completely 0.2.0 broken container, as no bash was in place and only added at testing time.