### PR TITLE
Fix wrong name of environment variable in analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ from this or a dedicated repo.
 
 The main executable is script is `bin/load_db_scxa_analytics.sh`, which requires the following environment variables to be set:
 - `EXP_ID`: Atlas Experiment identifier.
-- `ATLAS_SC_EXPERIMENTS`: The path to the directory where the `$EXP_ID/.expression_tpm.mtx[|_cols|_rows].gz` matrix market files reside.
+- `EXPERIMENT_MATRICES_PATH`: The path to the directory where the `$EXP_ID/.expression_tpm.mtx[|_cols|_rows].gz` matrix market files reside.
 - `dbConnection`: A postgres db connection string of the form `postgresql://{user}:{password}@{host:port}/{databaseName}` pointing to a postgres 10 server where the expected `scxa_analytics` table exists.
 
 Additionally, it is recommended that `bin` directory on the root is prepended to the `PATH`. Then execute:


### PR DESCRIPTION
The path variable used by `load_db_scxa_analytics.sh` was incorrect in the README file.