### PR TITLE
Do not insert 0 TPM values to scxa_analytics

### DIFF
--- a/bin/matrixMarket2csv.R
+++ b/bin/matrixMarket2csv.R
@@ -45,12 +45,16 @@ for(g_i in genes_steps) {
                         cell_id = runs_j$run[r_j],
                         expression = tpm_mtrx[g_i:up_to, r_j])
 
-    write.table(subset(chunk, expression > 0),
-                row.names = FALSE,
-                col.names = FALSE,
-                file = opt$output_path,
-                sep = ",",
-                append = TRUE,
-                quote = FALSE)
+    filtered_chunk <- subset(chunk, expression >0)
+
+    if (nrow(filtered_chunk) > 0) {
+      write.table(subset(chunk, expression > 0),
+                  row.names = FALSE,
+                  col.names = FALSE,
+                  file = opt$output_path,
+                  sep = ",",
+                  append = TRUE,
+                  quote = FALSE)
+    }
   }
 }

--- a/bin/matrixMarket2csv.R
+++ b/bin/matrixMarket2csv.R
@@ -3,7 +3,7 @@
 library(Matrix)
 library(optparse)
 
-option_list <- list( 
+option_list <- list(
   make_option(c("-m", "--matrix-file"), dest="matrix_path"),
   make_option(c("-r", "--rows-genes-file"), dest="genes_path"),
   make_option(c("-c", "--cols-runs-file"), dest="runs_path"),
@@ -17,29 +17,40 @@ opt <- parse_args(OptionParser(option_list=option_list))
 # following columns: experiment_accession, gene_id, cell_id, expression_level
 
 # Read data of the matrix
-readMM(gzfile(opt$matrix_path))->tpm_mtrx
+tpm_mtrx <- readMM(gzfile(opt$matrix_path))
 
 # Read rows (Genes), skipping index row. Is this safe? Is there always a gene name?
-genes_i<-read.table(file=gzfile(opt$genes_path),
-           header = FALSE,
-           col.names = c("index","gene"),
-           colClasses = c("NULL","character"))
-# Read columns (Cell-id/run)
-runs_j<-read.table(file=gzfile(opt$runs_path),
-           header=FALSE,
-           col.names = c("index","run"),
-           colClasses = c("NULL","character"))
-# Traverse tpm_mtrx object writing sequentially on an object that we write to disk, appending everynow and then.
+genes_i <- read.table(file = gzfile(opt$genes_path),
+                      header = FALSE,
+                      col.names = c("index", "gene"),
+                      colClasses = c("NULL", "character"))
 
-genes_per_it<-opt$genes_step
-genes_steps<-seq(1,nrow(genes_i),genes_per_it)
-num_genes<-nrow(genes_i)
+# Read columns (Cell-id/run)
+runs_j <- read.table(file = gzfile(opt$runs_path),
+                     header =   FALSE,
+                     col.names = c("index","run"),
+                     colClasses = c("NULL","character"))
+
+# Traverse tpm_mtrx object writing sequentially on an object that we write to disk, appending every now and then.
+genes_per_it <- opt$genes_step
+genes_steps <- seq(1, nrow(genes_i), genes_per_it)
+num_genes <- nrow(genes_i)
+
 for(g_i in genes_steps) {
   for(r_j in 1:nrow(runs_j)) {
-      up_to<-min(g_i+genes_per_it-1,num_genes)
-      write.table(data.frame(exp_acc=opt$exp_id,gene_id=genes_i$gene[g_i:up_to],
-                     cell_id=runs_j$run[r_j],expression=tpm_mtrx[g_i:up_to,r_j]),
-                row.names = FALSE, col.names = FALSE, file = opt$output_path, sep = ",",
-                append = TRUE, quote = FALSE)
+    up_to <- min(g_i + genes_per_it - 1, num_genes)
+
+    chunk <- data.frame(exp_acc = opt$exp_id,
+                        gene_id = genes_i$gene[g_i:up_to],
+                        cell_id = runs_j$run[r_j],
+                        expression = tpm_mtrx[g_i:up_to, r_j])
+
+    write.table(subset(chunk, expression > 0),
+                row.names = FALSE,
+                col.names = FALSE,
+                file = opt$output_path,
+                sep = ",",
+                append = TRUE,
+                quote = FALSE)
   }
 }

--- a/tests/random-data-set.bats
+++ b/tests/random-data-set.bats
@@ -16,6 +16,14 @@
   [ "$status" -eq 0 ]
 }
 
+@test "Analytics: Expression levels of 0 TPMs (i.e. missing entries in the matrix) are skipped" {
+  export EXP_ID=TEST-EXP1
+  count=$(echo "SELECT COUNT(*) FROM scxa_analytics WHERE expression_level = 0" | psql $dbConnection | awk 'NR==3')
+  run [ $count -eq 0 ]
+  echo "output = ${output}"
+  [ "$status" -eq 0 ]
+}
+
 @test "Analytics: Query and compare loaded files" {
   export EXP_ID=TEST-EXP1
   psql -A $dbConnection < $EXP_ID.query_test.sql | awk -F'|' '{ print $1,$2,$3,$4 }' | sed \$d > $EXP_ID.query_results.txt


### PR DESCRIPTION
This was a requirement in the earlier incarnation of the code that loaded the Matrix Market files to `scxa_analytics` through the web app.

I’m not fluent in R but I think that’s the most efficient way of filtering out the missing values. I added a test to verify the new behaviour.