### PR TITLE
Accept lack if signalled marker genes files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,14 @@ The main executable is `bin/load_db_scxa_marker_genes.sh`, which requires the fo
 - `EXPERIMENT_MGENES_PATH`: path of marker genes files for transforming and loading.
 - `dbConnection`: A postgres db connection string of the form `postgresql://{user}:{password}@{host:port}/{databaseName}` pointing to a postgres 10 server where the expected `scxa_marker_genes` table exists.
 
-Optionally, you can set the `CLUSTERS_FORMAT` variable to set the format to one of the following:
+Optionally, you can set `CLUSTERS_FORMAT` and `NUMBER_MGENES_FILES`:
+
+The `CLUSTERS_FORMAT` variable to set the format to one of the following:
 - `ISL` (default)
 - `SCANPY`
+
+The `NUMBER_MGENES_FILES` variable (zero or positive integer) hints whether there are marker genes files to be loaded. If the variable is set to zero by an external process, then the script won't fail if no
+marker genes files are found. Currently the script only considers whether the variable is 0 (no marker genes files) or greater (there are that number of marker gene files). This is mostly to be able to fail if we expected to have marker gene files but for some reasons these were not created due to an unknown issue.
 
 Additionally, it is recommended that `bin` directory on the root is prepended to the `PATH`. Then execute:
 

--- a/bin/load_db_scxa_marker_genes.sh
+++ b/bin/load_db_scxa_marker_genes.sh
@@ -28,57 +28,62 @@ if [[ ! "$CLUSTERS_FORMAT" =~ ^(ISL|SCANPY)$ ]]; then
     exit 1
 fi
 
-# Check that files are in place.
-[ $(ls -1 $EXPERIMENT_MGENES_PATH/$MGENES_PREFIX*$MGENES_SUFFIX | wc -l) -gt 0 ] \
-  || (echo "No marker gene files could be found on $EXPERIMENT_MGENES_PATH" && exit 1)
-
-
 # Check that database connection is valid
 checkDatabaseConnection $dbConnection
+
+if [[ -z ${NUMBER_MGENES_FILES+x} || $NUMBER_MGENES_FILES -gt 0 ]]; then
+  # Check that files are in place.
+  [ $(ls -1 $EXPERIMENT_MGENES_PATH/$MGENES_PREFIX*$MGENES_SUFFIX | wc -l) -gt 0 ] \
+    || (echo "No marker gene files could be found on $EXPERIMENT_MGENES_PATH" && exit 1)
+else
+  echo "WARNING No marker gene files declared on MANIFEST."
+fi
 
 # Delete marker gene table content for current EXP_ID
 echo "Marker genes: Delete rows for $EXP_ID:"
 echo "DELETE FROM scxa_marker_genes WHERE experiment_accession = '"$EXP_ID"'" | \
   psql $dbConnection
 
-# Create file with data
-# Please note that this relies on:
-# - Column ordering on the marker genes file: clusts padj auroc feat
-# - Table ordering of columns: experiment_accession gene_id k cluster_id marker_probability
-echo "Marker genes: Create data file for $EXP_ID..."
-rm -f $EXPERIMENT_MGENES_PATH/mgenesDataToLoad.csv
-for f in $(ls $EXPERIMENT_MGENES_PATH/$MGENES_PREFIX*$MGENES_SUFFIX); do
-  k=$(echo $f | sed s+$EXPERIMENT_MGENES_PATH/$MGENES_PREFIX++ | sed s/$MGENES_SUFFIX// )
-  if [ -e $EXPERIMENT_MGENES_PATH/$EXP_ID.clusters.tsv ]; then
-    # check that k is present in the second column of $EXP_ID.clusters.tsv,
-    # if such a file exists.
-    if ! awk '{ print $2 }' $EXPERIMENT_MGENES_PATH/$EXP_ID.clusters.tsv | tail -n +2 | grep -q ^$k$; then
-      echo "Skipping k=$k as it is not available in $EXP_ID.clusters.tsv file."
-      continue
+if [[ -z ${NUMBER_MGENES_FILES+x} || $NUMBER_MGENES_FILES -gt 0 ]]; then
+  # Create file with data
+  # Please note that this relies on:
+  # - Column ordering on the marker genes file: clusts padj auroc feat
+  # - Table ordering of columns: experiment_accession gene_id k cluster_id marker_probability
+  echo "Marker genes: Create data file for $EXP_ID..."
+  rm -f $EXPERIMENT_MGENES_PATH/mgenesDataToLoad.csv
+  for f in $(ls $EXPERIMENT_MGENES_PATH/$MGENES_PREFIX*$MGENES_SUFFIX); do
+    k=$(echo $f | sed s+$EXPERIMENT_MGENES_PATH/$MGENES_PREFIX++ | sed s/$MGENES_SUFFIX// )
+    if [ -e $EXPERIMENT_MGENES_PATH/$EXP_ID.clusters.tsv ]; then
+      # check that k is present in the second column of $EXP_ID.clusters.tsv,
+      # if such a file exists.
+      if ! awk '{ print $2 }' $EXPERIMENT_MGENES_PATH/$EXP_ID.clusters.tsv | tail -n +2 | grep -q ^$k$; then
+        echo "Skipping k=$k as it is not available in $EXP_ID.clusters.tsv file."
+        continue
+      fi
     fi
-  fi
-  if [ "$CLUSTERS_FORMAT" == "ISL" ]; then
-    # ISL produces marker genes with the following fields:
-    # clusts  padj    auroc   feat
-    tail -n +2 $f | awk -F'\t' -v EXP_ID="$EXP_ID" -v k_value="$k" 'BEGIN { OFS = ","; }
-    { print EXP_ID, $4, k_value, $1, $2 }' >> $EXPERIMENT_MGENES_PATH/mgenesDataToLoad.csv
-  elif [ "$CLUSTERS_FORMAT" == "SCANPY" ]; then
-    # Scanpy produces marker genes with the following fields:
-    # names   groups  scores  logfc   pvals   pvals_adj
-    tail -n +2 $f | awk -F'\t' -v EXP_ID="$EXP_ID" -v k_value="$k" 'BEGIN { OFS = ","; }
-    { print EXP_ID, $1, k_value, $2, $6 }' >> $EXPERIMENT_MGENES_PATH/mgenesDataToLoad.csv
-  else
-    echo "ERROR: unrecognized CLUSTERS_FORMAT '"$CLUSTERS_FORMAT"', aborting load."
-    echo "ERROR: this point should not have been reached..."
-    exit 1
-  fi
-done
+    if [ "$CLUSTERS_FORMAT" == "ISL" ]; then
+      # ISL produces marker genes with the following fields:
+      # clusts  padj    auroc   feat
+      tail -n +2 $f | awk -F'\t' -v EXP_ID="$EXP_ID" -v k_value="$k" 'BEGIN { OFS = ","; }
+      { print EXP_ID, $4, k_value, $1, $2 }' >> $EXPERIMENT_MGENES_PATH/mgenesDataToLoad.csv
+    elif [ "$CLUSTERS_FORMAT" == "SCANPY" ]; then
+      # Scanpy produces marker genes with the following fields:
+      # names   groups  scores  logfc   pvals   pvals_adj
+      tail -n +2 $f | awk -F'\t' -v EXP_ID="$EXP_ID" -v k_value="$k" 'BEGIN { OFS = ","; }
+      { print EXP_ID, $1, k_value, $2, $6 }' >> $EXPERIMENT_MGENES_PATH/mgenesDataToLoad.csv
+    else
+      echo "ERROR: unrecognized CLUSTERS_FORMAT '"$CLUSTERS_FORMAT"', aborting load."
+      echo "ERROR: this point should not have been reached..."
+      exit 1
+    fi
+  done
 
-# Load data
-echo "Marker genes: Loading data for $EXP_ID..."
-printf "\copy scxa_marker_genes (experiment_accession, gene_id, k, cluster_id, marker_probability) FROM '%s' WITH (DELIMITER ',');" $EXPERIMENT_MGENES_PATH/mgenesDataToLoad.csv | \
-  psql $dbConnection
+  # Load data
+  echo "Marker genes: Loading data for $EXP_ID..."
+  printf "\copy scxa_marker_genes (experiment_accession, gene_id, k, cluster_id, marker_probability) FROM '%s' WITH (DELIMITER ',');" $EXPERIMENT_MGENES_PATH/mgenesDataToLoad.csv | \
+    psql $dbConnection
 
-rm $EXPERIMENT_MGENES_PATH/mgenesDataToLoad.csv
+  rm $EXPERIMENT_MGENES_PATH/mgenesDataToLoad.csv
 
-echo "Marker genes: Loading done for $EXP_ID..."
+  echo "Marker genes: Loading done for $EXP_ID..."
+fi

--- a/tests/random-data-set.bats
+++ b/tests/random-data-set.bats
@@ -225,6 +225,24 @@
   [ "$status" -eq 0 ]
 }
 
+@test "Marker genes: Don't load Scanpy data with hint of number of marker genes files" {
+  export EXP_ID=TEST-EXP3
+  export NUMBER_MGENES_FILES=0
+  export CLUSTERS_FORMAT="SCANPY"
+  run load_db_scxa_marker_genes.sh
+  echo "output = ${output}"
+  [ "$status" -eq 0 ]
+}
+
+@test "Marker genes: Load Scanpy data with hint of number of marker genes files" {
+  export EXP_ID=TEST-EXP3
+  export NUMBER_MGENES_FILES=3
+  export CLUSTERS_FORMAT="SCANPY"
+  run load_db_scxa_marker_genes.sh
+  echo "output = ${output}"
+  [ "$status" -eq 0 ]
+}
+
 @test "TSNE: Check that load_db_scxa_tsne.sh is in the path" {
   run which load_db_scxa_tsne.sh
   echo "output = ${output}"


### PR DESCRIPTION
We face cases where a dataset might not include any marker genes, but the code was explicitly failing in those cases. This adds the ability to handle those cases but still fail if by error there are no marker genes (through hinting if we expect or not marker genes, for instance, if they are seen in the manifest).