### PR TITLE
Precomputed marker genes replacement for mv

### DIFF
--- a/bin/load_db_scxa_marker_genes.sh
+++ b/bin/load_db_scxa_marker_genes.sh
@@ -10,6 +10,8 @@ set -e
 scriptDir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source $scriptDir/db_scxa_common.sh
 
+postgres_scripts_dir=$scriptDir/../postgres_routines
+
 dbConnection=${dbConnection:-$1}
 EXP_ID=${EXP_ID:-$2}
 EXPERIMENT_MGENES_PATH=${EXPERIMENT_MGENES_PATH:-$3}
@@ -84,6 +86,10 @@ if [[ -z ${NUMBER_MGENES_FILES+x} || $NUMBER_MGENES_FILES -gt 0 ]]; then
     psql $dbConnection
 
   rm $EXPERIMENT_MGENES_PATH/mgenesDataToLoad.csv
+
+  echo "Precompute tables for marker genes queries..."
+  cat $postgres_scripts_dir/07-loading-marker-genes-precomputed.sql.template \
+    | sed "s/<<ACCESSION>>/$EXP_ID/" | psql $dbConnection
 
   echo "Marker genes: Loading done for $EXP_ID..."
 fi

--- a/bin/refresh_materialised_views.sh
+++ b/bin/refresh_materialised_views.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-echo "REFRESH MATERIALIZED VIEW scxa_top_5_marker_genes_per_cluster;" | psql $dbConnection
-echo "REFRESH MATERIALIZED VIEW scxa_marker_gene_stats;" | psql $dbConnection

--- a/bin/reindex_tables.sh
+++ b/bin/reindex_tables.sh
@@ -6,8 +6,8 @@ REINDEX TABLE scxa_marker_genes;
 REINDEX TABLE scxa_cell_clusters;
 REINDEX TABLE scxa_analytics;
 REINDEX TABLE experiment;
-REINDEX TABLE scxa_top_5_marker_genes_per_cluster;
-REINDEX TABLE scxa_marker_gene_stats;
+-- REINDEX TABLE scxa_top_5_marker_genes_per_cluster;
+-- REINDEX TABLE scxa_marker_gene_stats;
 
 CLUSTER;
 EOF

--- a/bin/reindex_tables.sh
+++ b/bin/reindex_tables.sh
@@ -6,6 +6,8 @@ REINDEX TABLE scxa_marker_genes;
 REINDEX TABLE scxa_cell_clusters;
 REINDEX TABLE scxa_analytics;
 REINDEX TABLE experiment;
+REINDEX TABLE scxa_top_5_marker_genes_per_cluster;
+REINDEX TABLE scxa_marker_gene_stats;
 
 CLUSTER;
 EOF

--- a/postgres_routines/07-loading-marker-genes-precomputed.sql.template
+++ b/postgres_routines/07-loading-marker-genes-precomputed.sql.template
@@ -15,7 +15,7 @@ SELECT x.r,
     x.marker_probability
    FROM (
          SELECT
-                    row_number() over (PARTITION BY scxa_marker_genes.k, scxa_marker_genes.cluster_id) as r,
+                    row_number() over (PARTITION BY scxa_marker_genes.k, scxa_marker_genes.cluster_id ORDER BY scxa_marker_genes.marker_probability) as r,
                     scxa_marker_genes.experiment_accession,
                     scxa_marker_genes.gene_id,
                     scxa_marker_genes.k,

--- a/postgres_routines/07-loading-marker-genes-precomputed.sql.template
+++ b/postgres_routines/07-loading-marker-genes-precomputed.sql.template
@@ -1,0 +1,49 @@
+DO $$
+
+DECLARE
+    exp_accession VARCHAR(255) := '<<ACCESSION>>';
+
+BEGIN
+
+DELETE FROM scxa_top_5_marker_genes_per_cluster WHERE experiment_accession = exp_accession;
+INSERT INTO scxa_top_5_marker_genes_per_cluster(r, experiment_accession, gene_id, k, cluster_id, marker_probability)
+SELECT x.r,
+    x.experiment_accession,
+    x.gene_id,
+    x.k,
+    x.cluster_id,
+    x.marker_probability
+   FROM (
+         SELECT
+                    row_number() over (PARTITION BY scxa_marker_genes.k, scxa_marker_genes.cluster_id) as r,
+                    scxa_marker_genes.experiment_accession,
+                    scxa_marker_genes.gene_id,
+                    scxa_marker_genes.k,
+                    scxa_marker_genes.cluster_id,
+                    scxa_marker_genes.marker_probability
+                    FROM scxa_marker_genes
+                    WHERE scxa_marker_genes.experiment_accession = exp_accession
+               ) x
+   WHERE x.r <= 5;
+
+DELETE FROM scxa_marker_gene_stats WHERE experiment_accession = exp_accession;
+INSERT INTO scxa_marker_gene_stats(experiment_accession, gene_id, k_where_marker, cluster_id_where_marker, cluster_id, marker_p_value, mean_expression, median_expression)
+SELECT analytics.experiment_accession,
+       analytics.gene_id,
+       markers.k                  AS k_where_marker,
+       markers.cluster_id         AS cluster_id_where_marker,
+       clusters.cluster_id,
+       markers.marker_probability AS marker_p_value,
+       avg(analytics.expression_level) AS mean_expression,
+       percentile_cont(0.5::double precision) WITHIN GROUP ( ORDER BY analytics.expression_level ) AS median_expression
+FROM scxa_analytics analytics
+         JOIN scxa_top_5_marker_genes_per_cluster markers
+              ON analytics.experiment_accession::text = markers.experiment_accession::text AND
+                 analytics.gene_id::text = markers.gene_id::text AND markers.experiment_accession = exp_accession
+         JOIN scxa_cell_clusters clusters
+              ON analytics.experiment_accession::text = clusters.experiment_accession::text AND
+                 analytics.cell_id::text = clusters.cell_id::text AND clusters.k = markers.k AND clusters.experiment_accession = exp_accession
+WHERE analytics.experiment_accession::text = exp_accession
+GROUP BY analytics.experiment_accession, analytics.gene_id, markers.k, markers.cluster_id, clusters.cluster_id, markers.marker_probability;
+
+END $$;

--- a/tests/marker-genes/01-optional-create-table.sql
+++ b/tests/marker-genes/01-optional-create-table.sql
@@ -14,3 +14,29 @@ CREATE TABLE IF NOT EXISTS scxa_marker_genes
     CONSTRAINT scxa_marker_genes_experiment_accession_gene_id_k_pk
     PRIMARY KEY (experiment_accession, gene_id, k)
 );
+
+CREATE TABLE IF NOT EXISTS scxa_top_5_marker_genes_per_cluster
+(
+    r integer not null,
+    experiment_accession varchar(255) not null,
+    gene_id varchar(255) not null,
+    k integer not null,
+    cluster_id integer not null,
+    marker_probability double precision not null,
+    constraint scxa_top_5_marker_genes_per_cluster_experiment_accession_gene_id_k_cluster_id_pk
+      primary key (experiment_accession, gene_id, k, cluster_id)
+);
+
+CREATE TABLE IF NOT EXISTS scxa_marker_gene_stats
+(
+    experiment_accession varchar(255) not null,
+    gene_id varchar(255) not null,
+    k_where_marker integer not null,
+    cluster_id_where_marker integer not null,
+    cluster_id integer not null,
+    marker_p_value double precision not null,
+    mean_expression float,
+    median_expression float,
+    constraint scxa_marker_gene_stats_experiment_accession_k_where_marker
+        primary key (experiment_accession, gene_id, k_where_marker, cluster_id_where_marker, cluster_id)
+);


### PR DESCRIPTION
Precomputes marker genes ranked tables to avoid usage of materialised views.