### PR TITLE
Default to aggregated filtered normalised counts

### DIFF
--- a/bin/load_db_scxa_analytics.sh
+++ b/bin/load_db_scxa_analytics.sh
@@ -20,7 +20,7 @@ postgres_scripts_dir=$scriptDir/../postgres_routines
 dbConnection=${dbConnection:-$1}
 EXP_ID=${EXP_ID:-$2}
 EXPERIMENT_MATRICES_PATH=${EXPERIMENT_MATRICES_PATH:-$3}
-EXPRESSION_TYPE=${EXPRESSION_TYPE:-"expression_tpm"}
+EXPRESSION_TYPE=${EXPRESSION_TYPE:-"aggregated_filtered_normalised_counts"}
 
 # Check that necessary environment variables are defined.
 [ -z ${dbConnection+x} ] && echo "Env var dbConnection for the database connection needs to be defined. This includes the database name." && exit 1


### PR DESCRIPTION
After the switch to counts, this makes more sense as a default, so we don’t need to set the env variable `EXPRESSION_TYPE` (which is undocumented, but that is less pressing, I guess)