### PR TITLE
Remove unlogged and minor changes to improve loading

### DIFF
--- a/bin/load_db_scxa_analytics.sh
+++ b/bin/load_db_scxa_analytics.sh
@@ -61,7 +61,8 @@ sed "s/<EXP-ACCESSION>/$lc_exp_acc/" $postgres_scripts_dir/02-create_and_load_pa
 rm $EXPERIMENT_MATRICES_PATH/expression2load.csv
 
 # Create primary key.
-sed "s/<EXP-ACCESSION>/$lc_exp_acc/g" $postgres_scripts_dir/04-build_pk.sql.template | \
+echo "Create PK"
+time sed "s/<EXP-ACCESSION>/$lc_exp_acc/g" $postgres_scripts_dir/04-build_pk.sql.template | \
     psql -v ON_ERROR_STOP=1 $dbConnection
 
 # Post-process partition table

--- a/bin/reindex_tables.sh
+++ b/bin/reindex_tables.sh
@@ -4,7 +4,6 @@ psql -v ON_ERROR_STOP=1 $dbConnection <<EOF
 REINDEX TABLE scxa_tsne;
 REINDEX TABLE scxa_marker_genes;
 REINDEX TABLE scxa_cell_clusters;
-REINDEX TABLE scxa_analytics;
 REINDEX TABLE experiment;
 
 CLUSTER;

--- a/postgres_routines/02-create_and_load_partition_table.sql.template
+++ b/postgres_routines/02-create_and_load_partition_table.sql.template
@@ -1,4 +1,11 @@
 /*
+  This script created a couple of unlogged tables which
+  will be used to load data and eventually plugged into
+  the master table as partitions
+*/
+CREATE TABLE scxa_analytics_<EXP-ACCESSION> (LIKE scxa_analytics) WITH (autovacuum_enabled = false, toast.autovacuum_enabled = false);
+
+/*
   The copy commands are specific to the psql PostgreSQL CLI
   Full file path of the CSV files must be specified
   WARNING: ensure that the CSV files contain ONLY the data that

--- a/postgres_routines/02-create_partition_table.sql.template
+++ b/postgres_routines/02-create_partition_table.sql.template
@@ -1,6 +1,0 @@
-/*
-  This script created a couple of unlogged tables which
-  will be used to load data and eventually plugged into
-  the master table as partitions
-*/
-CREATE UNLOGGED TABLE scxa_analytics_<EXP-ACCESSION> (LIKE scxa_analytics) WITH (autovacuum_enabled = false, toast.autovacuum_enabled = false);

--- a/postgres_routines/04-build_pk.sql.template
+++ b/postgres_routines/04-build_pk.sql.template
@@ -3,6 +3,6 @@
   to be used as partition
   NOTICE: the constraint name is <TABLE>_pk
 */
-SET maintenance_work_mem='1GB';
+SET maintenance_work_mem='2GB';
 alter table scxa_analytics_<EXP-ACCESSION> add constraint scxa_analytics_<EXP-ACCESSION>_pk PRIMARY KEY (gene_id, experiment_accession, cell_id);
 RESET maintenance_work_mem;

--- a/postgres_routines/05-post_processing.sql.template
+++ b/postgres_routines/05-post_processing.sql.template
@@ -8,6 +8,6 @@
 SET maintenance_work_mem='1GB';
 CLUSTER scxa_analytics_<EXP-ACCESSION> USING scxa_analytics_<EXP-ACCESSION>_pk;
 ANALYZE scxa_analytics_<EXP-ACCESSION>;
-RESET maintenance_work_mem ;
 alter table scxa_analytics_<EXP-ACCESSION> SET (autovacuum_enabled = true, toast.autovacuum_enabled = true);
 alter table scxa_analytics_<EXP-ACCESSION> add constraint check_e_ebi_<EXP-ACCESSION> check (experiment_accession='<EXP-ACC-UC>');
+RESET maintenance_work_mem ;

--- a/postgres_routines/05-post_processing.sql.template
+++ b/postgres_routines/05-post_processing.sql.template
@@ -5,7 +5,7 @@
     - re-enable autovacuum (mandatory)
     - add a check constraint on the partition value (mandatory)
 */
-SET maintenance_work_mem='1GB';
+SET maintenance_work_mem='2GB';
 CLUSTER scxa_analytics_<EXP-ACCESSION> USING scxa_analytics_<EXP-ACCESSION>_pk;
 ANALYZE scxa_analytics_<EXP-ACCESSION>;
 alter table scxa_analytics_<EXP-ACCESSION> SET (autovacuum_enabled = true, toast.autovacuum_enabled = true);


### PR DESCRIPTION
As recommended by DBA, a number of improvements to reduce loading time slightly for the analytics data:

- [x] Avoid unlogged table additions
- [x] create and load in the same transaction (instead right now you are creating first (commit) and load later after csv file is created)
- [ ] generate all the files on LSF cluster already sorted by pk key?
   - This will probably come at a later PR, possibly upstream on a different repo.
- [x] do you run analyze in post-processing? autovacuum will probably do it but better if you can run it
- [x] increase maintenance_work_mem (that should speed up operations like CREATE INDEX and ALTER TABLE ADD FOREIGN KEY): increased to 2 GB
- [x] move RESET maintenance_work_mem ; at the very end of the procedure it would be useful for add constraint statements
- [x] remove additional indexing operations: I think that is not necessary as indexes have just been built beforehand isn't it?