### PR TITLE
Use more memory for expensive wrap up operations.

### DIFF
--- a/bin/refresh_materialised_views.sh
+++ b/bin/refresh_materialised_views.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 set -e
-echo "REFRESH MATERIALIZED VIEW scxa_top_5_marker_genes_per_cluster;" | psql -v ON_ERROR_STOP=1 $dbConnection
-echo "REFRESH MATERIALIZED VIEW scxa_marker_gene_stats;" | psql -v ON_ERROR_STOP=1 $dbConnection
+
+psql -v ON_ERROR_STOP=1 $dbConnection <<EOF
+SET maintenance_work_mem='2GB';
+REFRESH MATERIALIZED VIEW scxa_top_5_marker_genes_per_cluster;
+REFRESH MATERIALIZED VIEW scxa_marker_gene_stats;
+RESET maintenance_work_mem;
+EOF

--- a/bin/reindex_tables.sh
+++ b/bin/reindex_tables.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -e
 psql -v ON_ERROR_STOP=1 $dbConnection <<EOF
+SET maintenance_work_mem='2GB';
 REINDEX TABLE scxa_tsne;
 REINDEX TABLE scxa_marker_genes;
 REINDEX TABLE scxa_cell_clusters;
 REINDEX TABLE experiment;
 
 CLUSTER;
+RESET maintenance_work_mem;
 EOF


### PR DESCRIPTION
This operations were all running with the default amount of memory (256MB). This should improve things up.