### PR TITLE
Do not cluster analytics (already clustered individually)

### DIFF
--- a/bin/reindex_tables.sh
+++ b/bin/reindex_tables.sh
@@ -7,6 +7,9 @@ REINDEX TABLE scxa_marker_genes;
 REINDEX TABLE scxa_cell_clusters;
 REINDEX TABLE experiment;
 
-CLUSTER;
+CLUSTER scxa_tsne;
+CLUSTER scxa_marker_genes;
+CLUSTER scxa_cell_clusters;
+CLUSTER experiment;
 RESET maintenance_work_mem;
 EOF


### PR DESCRIPTION
Currently the partitioned tables are being clustered on their own, so it makes no sense to cluster the entire table at the end, saving around 14 hours of processing.