### PR TITLE
Only add inferred cell type characteristic to db, not the factor value

### DIFF
--- a/bin/load_db_scxa_cell_clusters.sh
+++ b/bin/load_db_scxa_cell_clusters.sh
@@ -79,7 +79,7 @@ if [ -n "$CONDENSED_SDRF_TSV" ]; then
   for additionalCellGroupType in "${additionalCellGroupTypes[@]}"; do
     grep -m 1 "$(printf '\t')$additionalCellGroupType$(printf '\t')" $CONDENSED_SDRF_TSV >/dev/null
     if [ $? -eq 0 ]; then
-        grep "$(printf '\t')$additionalCellGroupType$(printf '\t')" $CONDENSED_SDRF_TSV | awk -F'\t' 'BEGIN { OFS = "|"; } {print $1,$3,$5,$6}' >> $groupMembershipsToLoad    
+        grep "$(printf '\t')$additionalCellGroupType$(printf '\t')" $CONDENSED_SDRF_TSV | grep 'characteristic' | awk -F'\t' 'BEGIN { OFS = "|"; } {print $1,$3,$5,$6}' >> $groupMembershipsToLoad    
         
         # Add the option of the unknown cell type
         echo "${EXP_ID}|$additionalCellGroupType|Not available" >> ${groupsToLoad}.tmp

--- a/bin/load_db_scxa_cell_clusters.sh
+++ b/bin/load_db_scxa_cell_clusters.sh
@@ -79,7 +79,7 @@ if [ -n "$CONDENSED_SDRF_TSV" ]; then
   for additionalCellGroupType in "${additionalCellGroupTypes[@]}"; do
     grep -m 1 "$(printf '\t')$additionalCellGroupType$(printf '\t')" $CONDENSED_SDRF_TSV >/dev/null
     if [ $? -eq 0 ]; then
-        grep "$(printf '\t')$additionalCellGroupType$(printf '\t')" $CONDENSED_SDRF_TSV | grep 'characteristic' | awk -F'\t' 'BEGIN { OFS = "|"; } {print $1,$3,$5,$6}' >> $groupMembershipsToLoad    
+        grep "$(printf '\t')$additionalCellGroupType$(printf '\t')" $CONDENSED_SDRF_TSV | grep 'characteristic' | awk -F'\t' 'BEGIN { OFS = "|"; } {print $1,$3,$5,$6}' | sed 's/ *$//' >> $groupMembershipsToLoad    
         
         # Add the option of the unknown cell type
         echo "${EXP_ID}|$additionalCellGroupType|Not available" >> ${groupsToLoad}.tmp

--- a/bin/load_db_scxa_cell_clusters.sh
+++ b/bin/load_db_scxa_cell_clusters.sh
@@ -79,7 +79,7 @@ if [ -n "$CONDENSED_SDRF_TSV" ]; then
   for additionalCellGroupType in "${additionalCellGroupTypes[@]}"; do
     grep -m 1 "$(printf '\t')$additionalCellGroupType$(printf '\t')" $CONDENSED_SDRF_TSV >/dev/null
     if [ $? -eq 0 ]; then
-        grep "$(printf '\t')$additionalCellGroupType$(printf '\t')" $CONDENSED_SDRF_TSV | grep 'characteristic' | awk -F'\t' 'BEGIN { OFS = "|"; } {print $1,$3,$5,$6}' | sed 's/ *$//' >> $groupMembershipsToLoad    
+        grep "$(printf '\t')$additionalCellGroupType$(printf '\t')" $CONDENSED_SDRF_TSV | sort | uniq | awk -F'\t' 'BEGIN { OFS = "|"; } {print $1,$3,$5,$6}' | sed 's/ *$//' >> $groupMembershipsToLoad    
         
         # Add the option of the unknown cell type
         echo "${EXP_ID}|$additionalCellGroupType|Not available" >> ${groupsToLoad}.tmp

--- a/bin/load_db_scxa_marker_genes.sh
+++ b/bin/load_db_scxa_marker_genes.sh
@@ -36,7 +36,6 @@ print_log() {
 }
 
 # Check that database connection is valid
-echo checkDatabaseConnection $dbConnection
 checkDatabaseConnection $dbConnection
 
 # Input files may expect in the bundles


### PR DESCRIPTION
At least one of the current load errors is due to parsing of inferred cell type from both characteristic and factor fields in the condensed SDRF. This simple fix uses only the characteristic. 