### PR TITLE
Remove explicit marker table row deletions and rely on cascades

### DIFF
--- a/bin/load_db_scxa_cell_clusters.sh
+++ b/bin/load_db_scxa_cell_clusters.sh
@@ -102,10 +102,6 @@ cat ${groupsToLoad}.tmp | sort -t$'|' -k 1,1 | uniq > $groupsToLoad
 
 # Delete existing content- including via FKs (though this should really cascade now)
 print_log "Deleting existing grouping data..."
-echo "DELETE FROM scxa_cell_group_marker_gene_stats WHERE cell_group_id in (select id from scxa_cell_group where experiment_accession = '"$EXP_ID"')" | \
-  psql -v ON_ERROR_STOP=1 $dbConnection
-echo "DELETE FROM scxa_cell_group_marker_genes WHERE cell_group_id in (select id from scxa_cell_group where experiment_accession = '"$EXP_ID"')" | \
-  psql -v ON_ERROR_STOP=1 $dbConnection
 echo "DELETE FROM scxa_cell_group WHERE experiment_accession = '"$EXP_ID"'" | \
   psql -v ON_ERROR_STOP=1 $dbConnection
 print_log "Copying cell groups data to the db..."


### PR DESCRIPTION
Marker genes, and marker gene stats tables have cascade relationships that should cause any rows associated with particular cell groups to be deleted as the parent cell groups are deleted:

```
> echo "\d scxa_cell_group_marker_genes" | psql $dbConnection
                                        Table "atlasprd3.scxa_cell_group_marker_genes"
       Column       |          Type          | Collation | Nullable |                         Default                          
--------------------+------------------------+-----------+----------+----------------------------------------------------------
 id                 | integer                |           | not null | nextval('scxa_cell_group_marker_genes_id_seq'::regclass)
 gene_id            | character varying(255) |           | not null | 
 cell_group_id      | integer                |           |          | 
 marker_probability | double precision       |           |          | 
Indexes:
    "scxa_cell_group_marker_genes_pkey" PRIMARY KEY, btree (id)
    "scxa_cell_group_marker_genes_gene_id_cell_group_id_key" UNIQUE CONSTRAINT, btree (gene_id, cell_group_id)
    "scxa_cell_group_marker_genes_cell_group_id" btree (cell_group_id)
Foreign-key constraints:
    "scxa_cell_group_marker_genes_cell_group_id_fkey" FOREIGN KEY (cell_group_id) REFERENCES scxa_cell_group(id) ON DELETE CASCADE
Referenced by:
    TABLE "scxa_cell_group_marker_gene_stats" CONSTRAINT "scxa_cell_group_marker_gene_stats_marker_id_fkey" FOREIGN KEY (marker_id) REFERENCES scxa_cell_group_marker_genes(id) ON DELETE CASCADE
```

```
echo "\d scxa_cell_group_marker_gene_stats" | psql $dbConnection
             Table "atlasprd3.scxa_cell_group_marker_gene_stats"
      Column       |          Type          | Collation | Nullable | Default 
-------------------+------------------------+-----------+----------+---------
 gene_id           | character varying(255) |           | not null | 
 cell_group_id     | integer                |           |          | 
 marker_id         | integer                |           |          | 
 expression_type   | smallint               |           | not null | 
 mean_expression   | double precision       |           | not null | 
 median_expression | double precision       |           | not null | 
Indexes:
    "scxa_cell_group_marker_gene_s_gene_id_cell_group_id_marker__key" UNIQUE CONSTRAINT, btree (gene_id, cell_group_id, marker_id, expression_type)
    "scxa_cell_group_marker_gene_stats_cell_group_id" btree (cell_group_id)
    "scxa_cell_group_marker_gene_stats_expression_type" btree (expression_type)
Foreign-key constraints:
    "scxa_cell_group_marker_gene_stats_cell_group_id_fkey" FOREIGN KEY (cell_group_id) REFERENCES scxa_cell_group(id) ON DELETE CASCADE
    "scxa_cell_group_marker_gene_stats_marker_id_fkey" FOREIGN KEY (marker_id) REFERENCES scxa_cell_group_marker_genes(id) ON DELETE CASCADE
```

Perhaps down to an overabundance of caution, I have not previously relied on this, preferring to make sure rows are deleted with explicit deletes (marker stats, markers, then cell groups). However this is creating difficulties because the deletion queries are using queries that consume large proportions of our load time.

This PR removes explicit deletes for marker genes and associated statistics. Rows in these tables will now be deletes as a consequence of the cascading dependencies from cell groups, which should be much quicker. 

