### PR TITLE
Upload coordinates to json column instead of now-deleted varchar column

### DIFF
--- a/bin/load_db_scxa_dimred.sh
+++ b/bin/load_db_scxa_dimred.sh
@@ -86,7 +86,7 @@ for dimred_type in tsne umap; do
 
   for f in $(ls $EXPERIMENT_DIMRED_PATH/$dimred_prefix*$DIMRED_SUFFIX); do
     paramval=$(echo $f | sed s+$EXPERIMENT_DIMRED_PATH/$dimred_prefix++ | sed s/$DIMRED_SUFFIX// )
-    tail -n +2 $f | awk -F'\t' -v EXP_ID="$EXP_ID" -v params="$dimred_param=$paramval" -v method="$dimred_type" 'BEGIN { OFS = ","; }
+    tail -n +2 $f | awk -F'\t' -v EXP_ID="$EXP_ID" -v params="[{\"$dimred_param\": $paramval}]" -v method="$dimred_type" 'BEGIN { OFS = ","; }
     { print EXP_ID, method, $1, $2, $3, params }' >> $EXPERIMENT_DIMRED_PATH/dimredDataToLoad.csv
   done
 done
@@ -95,7 +95,7 @@ done
 echo "coords: Loading data for $EXP_ID..."
 
 set +e
-printf "\copy scxa_coords (experiment_accession, method, cell_id, x, y, parameterisation) FROM '%s' WITH (DELIMITER ',');" $EXPERIMENT_DIMRED_PATH/dimredDataToLoad.csv | \
+printf "\copy scxa_coords (experiment_accession, method, cell_id, x, y, json_parameterisation) FROM '%s' WITH (DELIMITER ',');" $EXPERIMENT_DIMRED_PATH/dimredDataToLoad.csv | \
   psql -v ON_ERROR_STOP=1 $dbConnection
 
 s=$?

--- a/bin/load_db_scxa_dimred.sh
+++ b/bin/load_db_scxa_dimred.sh
@@ -95,7 +95,7 @@ done
 echo "coords: Loading data for $EXP_ID..."
 
 set +e
-printf "\copy scxa_coords (experiment_accession, method, cell_id, x, y, json_parameterisation) FROM '%s' WITH (DELIMITER ',');" $EXPERIMENT_DIMRED_PATH/dimredDataToLoad.csv | \
+printf "\copy scxa_coords (experiment_accession, method, cell_id, x, y, parameterisation) FROM '%s' WITH (DELIMITER ',');" $EXPERIMENT_DIMRED_PATH/dimredDataToLoad.csv | \
   psql -v ON_ERROR_STOP=1 $dbConnection
 
 s=$?

--- a/tests/random-data-set.bats
+++ b/tests/random-data-set.bats
@@ -275,6 +275,12 @@
   [ "$status" -eq 0 ]
 }
 
+@test "Dimred parameters: check that JSON queries run and return expected values" {
+    target_perps="1 5 10 15 20  "
+    perps=$(echo "select distinct parameterisation->0->'perplexity' as perplexity from scxa_coords order by perplexity" | psql -At $dbConnection | tr '\n' ' ')
+    run [ "$perps" = "$target_perps" ]
+}
+
 @test "TSNE: Check number of loaded rows" {
   # Get third line with count of total entries in the database after our load
   count=$(echo "SELECT COUNT(*) FROM scxa_tsne" | psql -v ON_ERROR_STOP=1 $dbConnection | awk 'NR==3')


### PR DESCRIPTION
This PR switches loading code to use a JSONB parameterisation column in preference to the old string column, in the generic coordinates table.

See https://github.com/ebi-gene-expression-group/atlas-schemas/pull/18, https://github.com/ebi-gene-expression-group/atlas-schemas/pull/19