### PR TITLE
Update delete_db_scxa_cell_clusters.sh

### DIFF
--- a/bin/delete_db_scxa_cell_clusters.sh
+++ b/bin/delete_db_scxa_cell_clusters.sh
@@ -7,3 +7,4 @@ dbConnection=${dbConnection:-$1}
 EXP_ID=${EXP_ID:-$2}
 
 echo "DELETE FROM scxa_cell_clusters WHERE experiment_accession = '"$EXP_ID"'" | psql -v ON_ERROR_STOP=1 $dbConnection
+echo "DELETE FROM scxa_cell_group WHERE experiment_accession = '"$EXP_ID"'" | psql -v ON_ERROR_STOP=1 $dbConnection


### PR DESCRIPTION
This PR deletes rows from the new generic cell groups table, and will cascade to delete rows in the new marker genes table.

Alternatively, we could delete the experiment from the experiments table (if we don't need to retain it there for some reason), which would cascade to the cell groups table without this change. 