### PR TITLE
Remove references to scxa_tsne table, use base container, M1 partly native

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM continuumio/miniconda3:4.8.2
+FROM mambaorg/micromamba:0.17.0
 # debian
 
-RUN /opt/conda/bin/conda config --add channels defaults && \
-    /opt/conda/bin/conda config --add channels conda-forge && \
-    /opt/conda/bin/conda config --add channels bioconda && \
-    /opt/conda/bin/conda install r-base r-tidyr r-optparse r-matrix openjdk r-data.table
+RUN micromamba config --add channels defaults && \
+    micromamba config --add channels conda-forge && \
+    micromamba config --add channels bioconda && \
+    micromamba install r-base r-tidyr r-optparse r-matrix openjdk r-data.table
 
 USER root
 # RUN apk update && apk add postgresql-client bash wget nodejs bats

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,3 @@ ADD postgres_routines /usr/local/postgres_routines
 USER root
 RUN chmod a+w /usr/local
 USER micromamba
-
-ENV PATH "/bin:/sbin:/usr/bin:/usr/local/bin:/opt/conda/bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM quay.io/ebigxa/atlas-db-scxa-base:0.1.0
 ADD bin/* /usr/local/bin/
 ADD postgres_routines /usr/local/postgres_routines
 USER root
-chmod a+w /usr/local
+RUN chmod a+w /usr/local
 USER micromamba
 
 ENV PATH "/bin:/sbin:/usr/bin:/usr/local/bin:/opt/conda/bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM mambaorg/micromamba:0.17.0
+FROM continuumio/miniconda3:4.10.3
 # debian
 
-RUN micromamba config --add channels defaults && \
-    micromamba config --add channels conda-forge && \
-    micromamba config --add channels bioconda && \
-    micromamba install r-base r-tidyr r-optparse r-matrix openjdk r-data.table
+RUN /opt/conda/bin/conda config --add channels defaults && \
+    /opt/conda/bin/conda config --add channels conda-forge && \
+    /opt/conda/bin/conda config --add channels bioconda && \
+    /opt/conda/bin/conda install r-base r-tidyr r-optparse r-matrix openjdk r-data.table
 
 USER root
 # RUN apk update && apk add postgresql-client bash wget nodejs bats

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,8 @@ FROM quay.io/ebigxa/atlas-db-scxa-base:0.1.0
 
 ADD bin/* /usr/local/bin/
 ADD postgres_routines /usr/local/postgres_routines
+USER root
+chmod a+w /usr/local
+USER micromamba
 
 ENV PATH "/bin:/sbin:/usr/bin:/usr/local/bin:/opt/conda/bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,5 @@
-FROM continuumio/miniconda3:4.10.3
+FROM quay.io/ebigxa/atlas-db-scxa-base:0.1.0
 # debian
-
-RUN /opt/conda/bin/conda config --add channels defaults && \
-    /opt/conda/bin/conda config --add channels conda-forge && \
-    /opt/conda/bin/conda config --add channels bioconda && \
-    /opt/conda/bin/conda install r-base r-tidyr r-optparse r-matrix openjdk r-data.table
-
-USER root
-# RUN apk update && apk add postgresql-client bash wget nodejs bats
-RUN apt-get update && apt-get install -y postgresql-client wget nodejs bats
-RUN wget -qO- https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/6.3.2/flyway-commandline-6.3.2-linux-x64.tar.gz | tar xvz && ln -s `pwd`/flyway-6.3.2/flyway /usr/local/bin
 
 ADD bin/* /usr/local/bin/
 ADD postgres_routines /usr/local/postgres_routines

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ export dbConnection=...
 delete_db_scxa_analytics.sh
 ```
 
-# `scxa_tsne` Table
+# `scxa_coords` Table
 
 ## Create schema
 
@@ -44,8 +44,8 @@ Same as in `scxa_analytics` currently.
 
 The main executable is `bin/load_db_scxa_dimred.sh`, which requires the following environment variables to be set:
 - `EXP_ID`: Atlas experiment identifier.
-- `EXPERIMENT_DIMRED_PATH`: path to directory containing tsne files for loading. Files are expected to have the structure <prefix><perplexity_number><suffix>, with the default suffix and prefix defined in the script. These can be configured from outside through env vars.
-- `dbConnection`: A postgres db connection string of the form `postgresql://{user}:{password}@{host:port}/{databaseName}` pointing to a Postgres 10 server where the expected `scxa_tsne` and `scxa_coords` tables exist.
+- `EXPERIMENT_DIMRED_PATH`: path to directory containing tsne and umap files for loading. Files are expected to have the structure <prefix><perplexity_number><suffix> (tsne) or <prefix><neighbors_number><suffix> (umap) with the default suffix and prefix defined in the script. These can be configured from outside through env vars.
+- `dbConnection`: A postgres db connection string of the form `postgresql://{user}:{password}@{host:port}/{databaseName}` pointing to a Postgres 10 server where the expected `scxa_coords` table exist.
 
 Additionally, it is recommended that `bin` directory on the root is prepended to the `PATH`. Then execute:
 

--- a/bin/delete_db_scxa_dimred.sh
+++ b/bin/delete_db_scxa_dimred.sh
@@ -6,7 +6,5 @@ set -e
 dbConnection=${dbConnection:-$1}
 EXP_ID=${EXP_ID:-$2}
 
-echo "DELETE FROM scxa_tsne WHERE experiment_accession = '"$EXP_ID"'" | psql -v ON_ERROR_STOP=1 $dbConnection
-
 echo "DELETE FROM scxa_coords WHERE experiment_accession = '"$EXP_ID"'" | \
   psql -v ON_ERROR_STOP=1 $dbConnection

--- a/bin/reindex_tables.sh
+++ b/bin/reindex_tables.sh
@@ -2,12 +2,12 @@
 set -e
 psql -v ON_ERROR_STOP=1 $dbConnection <<EOF
 SET maintenance_work_mem='2GB';
-REINDEX TABLE scxa_tsne;
+REINDEX TABLE scxa_coord;
 REINDEX TABLE scxa_marker_genes;
 REINDEX TABLE scxa_cell_clusters;
 REINDEX TABLE experiment;
 
-CLUSTER scxa_tsne USING scxa_tsne_experiment_accession_cell_id_perplexity_pk;
+#CLUSTER scxa_tsne USING scxa_tsne_experiment_accession_cell_id_perplexity_pk;
 CLUSTER scxa_marker_genes USING scxa_marker_genes_experiment_accession_gene_id_k_cluster_id_pk;
 CLUSTER scxa_cell_clusters USING scxa_cell_clusters_experiment_accession_cell_id_k_pk;
 RESET maintenance_work_mem;

--- a/bin/reindex_tables.sh
+++ b/bin/reindex_tables.sh
@@ -2,7 +2,7 @@
 set -e
 psql -v ON_ERROR_STOP=1 $dbConnection <<EOF
 SET maintenance_work_mem='2GB';
-REINDEX TABLE scxa_coord;
+REINDEX TABLE scxa_coords;
 REINDEX TABLE scxa_marker_genes;
 REINDEX TABLE scxa_cell_clusters;
 REINDEX TABLE experiment;

--- a/bin/reindex_tables.sh
+++ b/bin/reindex_tables.sh
@@ -7,7 +7,6 @@ REINDEX TABLE scxa_marker_genes;
 REINDEX TABLE scxa_cell_clusters;
 REINDEX TABLE experiment;
 
-#CLUSTER scxa_tsne USING scxa_tsne_experiment_accession_cell_id_perplexity_pk;
 CLUSTER scxa_marker_genes USING scxa_marker_genes_experiment_accession_gene_id_k_cluster_id_pk;
 CLUSTER scxa_cell_clusters USING scxa_cell_clusters_experiment_accession_cell_id_k_pk;
 RESET maintenance_work_mem;

--- a/run_tests_with_containers.sh
+++ b/run_tests_with_containers.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 # Above ^^ will test that bash is installed
 
+docker_arch_line=""
+if [ $( arch ) == "arm64" ]; then
+    docker_arch_line="--platform linux/amd64"
+    echo "Changing arch $docker_arch_line"
+fi
+
 dbConnection='postgresql://scxa:postgresPass@postgres/scxa-test'
 docker stop postgres && docker rm postgres
 docker network rm mynet
 docker network create mynet
-docker run --name postgres --net mynet -e POSTGRES_PASSWORD=postgresPass -e POSTGRES_USER=scxa -e POSTGRES_DB=scxa-test -p 5432:5432 -d postgres:10.3-alpine
-docker build -t test/db-scxa-module .
-docker run --net mynet -i -v $( pwd )/tests:/usr/local/tests:rw -e dbConnection=$dbConnection -v $( pwd )/atlas-schemas:/tmp/atlas-schemas:rw --entrypoint=/usr/local/tests/run_tests.sh test/db-scxa-module
+docker run --name postgres --net mynet -e POSTGRES_PASSWORD=postgresPass -e POSTGRES_USER=scxa -e POSTGRES_DB=scxa-test -p 5432:5432 -d postgres:10-alpine3.15
+docker build $docker_arch_line -t test/db-scxa-module .
+docker run $docker_arch_line --net mynet -i -v $( pwd )/tests:/usr/local/tests:rw -e dbConnection=$dbConnection -v $( pwd )/atlas-schemas:/tmp/atlas-schemas:rw --entrypoint=/usr/local/tests/run_tests.sh test/db-scxa-module

--- a/run_tests_with_containers.sh
+++ b/run_tests_with_containers.sh
@@ -7,4 +7,4 @@ docker network rm mynet
 docker network create mynet
 docker run --name postgres --net mynet -e POSTGRES_PASSWORD=postgresPass -e POSTGRES_USER=scxa -e POSTGRES_DB=scxa-test -p 5432:5432 -d postgres:10.3-alpine
 docker build -t test/db-scxa-module .
-docker run --net mynet -i -v $( pwd )/tests:/usr/local/tests -e dbConnection=$dbConnection -v $( pwd )/atlas-schemas:/atlas-schemas --entrypoint=/usr/local/tests/run_tests.sh test/db-scxa-module
+docker run --net mynet -i -v $( pwd )/tests:/usr/local/tests -e dbConnection=$dbConnection -v $( pwd )/atlas-schemas:/tmp/atlas-schemas --entrypoint=/usr/local/tests/run_tests.sh test/db-scxa-module

--- a/run_tests_with_containers.sh
+++ b/run_tests_with_containers.sh
@@ -7,4 +7,4 @@ docker network rm mynet
 docker network create mynet
 docker run --name postgres --net mynet -e POSTGRES_PASSWORD=postgresPass -e POSTGRES_USER=scxa -e POSTGRES_DB=scxa-test -p 5432:5432 -d postgres:10.3-alpine
 docker build -t test/db-scxa-module .
-docker run --net mynet -i -v $( pwd )/tests:/usr/local/tests -e dbConnection=$dbConnection -v $( pwd )/atlas-schemas:/tmp/atlas-schemas --entrypoint=/usr/local/tests/run_tests.sh test/db-scxa-module
+docker run --net mynet -i -v $( pwd )/tests:/usr/local/tests:rw -e dbConnection=$dbConnection -v $( pwd )/atlas-schemas:/tmp/atlas-schemas:rw --entrypoint=/usr/local/tests/run_tests.sh test/db-scxa-module

--- a/tests/random-data-set.bats
+++ b/tests/random-data-set.bats
@@ -211,7 +211,7 @@
   [ "$status" -eq 0 ]
 }
 
-@test "Marker genes: Add second dataset for deletion tests" {
+@test "Marker genes: Add second dataset for deletion tests and do cell clusters" {
   cp $testsDir/marker-genes/TEST-EXP1.clusters.tsv $SCRATCH_DIR/TEST-EXP2.clusters.tsv
   cp $testsDir/marker-genes/TEST-EXP1.marker_genes_9.tsv $SCRATCH_DIR/TEST-EXP2.marker_genes_9.tsv
   cp $testsDir/marker-genes/TEST-EXP1.marker_genes_10.tsv $SCRATCH_DIR/TEST-EXP2.marker_genes_10.tsv
@@ -220,6 +220,16 @@
   export EXPERIMENT_MGENES_PATH=$SCRATCH_DIR
   export EXPERIMENT_CLUSTERS_FILE=$SCRATCH_DIR/TEST-EXP2.clusters.tsv
   run load_db_scxa_cell_clusters.sh
+  
+  echo "output = ${output}"
+  [ "$status" -eq 0 ]
+}
+
+@test "Marker genes: Marker genes for second dataset for deletion tests" {
+  export EXP_ID=TEST-EXP2
+  export EXPERIMENT_MGENES_PATH=$SCRATCH_DIR
+  export EXPERIMENT_CLUSTERS_FILE=$SCRATCH_DIR/TEST-EXP2.clusters.tsv
+
   run load_db_scxa_marker_genes.sh
   echo "output = ${output}"
   [ "$status" -eq 0 ]

--- a/tests/random-data-set.bats
+++ b/tests/random-data-set.bats
@@ -212,13 +212,11 @@
 }
 
 @test "Marker genes: Add second dataset for deletion tests and do cell clusters" {
-  cp $testsDir/marker-genes/TEST-EXP1.clusters.tsv $SCRATCH_DIR/TEST-EXP2.clusters.tsv
-  cp $testsDir/marker-genes/TEST-EXP1.marker_genes_9.tsv $SCRATCH_DIR/TEST-EXP2.marker_genes_9.tsv
-  cp $testsDir/marker-genes/TEST-EXP1.marker_genes_10.tsv $SCRATCH_DIR/TEST-EXP2.marker_genes_10.tsv
-  cp $testsDir/marker-genes/TEST-EXP1.marker_genes_11.tsv $SCRATCH_DIR/TEST-EXP2.marker_genes_11.tsv
+  cp -r $testsDir/marker-genes $SCRATCH_DIR/
+
   export EXP_ID=TEST-EXP2
-  export EXPERIMENT_MGENES_PATH=$SCRATCH_DIR
-  export EXPERIMENT_CLUSTERS_FILE=$SCRATCH_DIR/TEST-EXP2.clusters.tsv
+  export EXPERIMENT_MGENES_PATH=$SCRATCH_DIR/marker-genes
+  export EXPERIMENT_CLUSTERS_FILE=$SCRATCH_DIR/marker-genes/TEST-EXP2.clusters.tsv
   run load_db_scxa_cell_clusters.sh
   
   echo "output = ${output}"
@@ -227,8 +225,8 @@
 
 @test "Marker genes: Marker genes for second dataset for deletion tests" {
   export EXP_ID=TEST-EXP2
-  export EXPERIMENT_MGENES_PATH=$SCRATCH_DIR
-  export EXPERIMENT_CLUSTERS_FILE=$SCRATCH_DIR/TEST-EXP2.clusters.tsv
+  export EXPERIMENT_MGENES_PATH=$SCRATCH_DIR/marker_genes
+  export EXPERIMENT_CLUSTERS_FILE=$SCRATCH_DIR/marker_genes/TEST-EXP2.clusters.tsv
 
   run load_db_scxa_marker_genes.sh
   echo "output = ${output}"

--- a/tests/random-data-set.bats
+++ b/tests/random-data-set.bats
@@ -212,7 +212,7 @@
 }
 
 @test "Marker genes: Add second dataset for deletion tests and do cell clusters" {
-  cp -r $testsDir/marker-genes $SCRATCH_DIR/
+  cp -r $testsDir/marker-genes $SCRATCH_DIR/marker_genes
 
   export EXP_ID=TEST-EXP2
   export EXPERIMENT_MGENES_PATH=$SCRATCH_DIR/marker-genes

--- a/tests/random-data-set.bats
+++ b/tests/random-data-set.bats
@@ -262,42 +262,8 @@
   [ "$status" -eq 0 ]
 }
 
-@test "TSNE: Check that load_db_scxa_dimred.sh is in the path" {
+@test "TSNE and UMAP: Check that load_db_scxa_dimred.sh is in the path" {
   run which load_db_scxa_dimred.sh
-  echo "output = ${output}"
-  [ "$status" -eq 0 ]
-}
-
-@test "TSNE: Load data" {
-  export EXP_ID=TEST-EXP1
-  run load_db_scxa_dimred.sh
-  echo "output = ${output}"
-  [ "$status" -eq 0 ]
-}
-
-@test "Dimred parameters: check that JSON queries run and return expected values" {
-    target_perps="1 5 10 15 20  "
-    perps=$(echo "select distinct parameterisation->0->'perplexity' as perplexity from scxa_coords order by perplexity" | psql -At $dbConnection | tr '\n' ' ')
-    run [ "$perps" = "$target_perps" ]
-}
-
-@test "TSNE: Check number of loaded rows" {
-  # Get third line with count of total entries in the database after our load
-  count=$(echo "SELECT COUNT(*) FROM scxa_tsne" | psql -v ON_ERROR_STOP=1 $dbConnection | awk 'NR==3')
-  # TODO improve, highly dependent on test files we have, but in a hurry for now.
-  run [ $count -eq 250 ]
-  echo "output = ${output}"
-  [ "$status" -eq 0 ]
-}
-
-@test "TSNE: Delete experiment" {
-  export EXP_ID=TEST-EXP1
-  run delete_db_scxa_dimred.sh
-  echo "output = ${output}"
-  [ "$status" -eq 0 ]
-  count=$(echo "SELECT COUNT(*) FROM scxa_tsne WHERE experiment_accession = '"$EXP_ID"'" | psql -v ON_ERROR_STOP=1 $dbConnection | awk 'NR==3')
-  # TODO improve, highly dependent on test files we have, but in a hurry for now.
-  run [ $count -eq 0 ]
   echo "output = ${output}"
   [ "$status" -eq 0 ]
 }

--- a/tests/random-data-set.bats
+++ b/tests/random-data-set.bats
@@ -289,7 +289,7 @@
   # Get third line with count of total entries in the database after our load
   count=$(echo "SELECT COUNT(*) FROM scxa_coords" | psql -v ON_ERROR_STOP=1 $dbConnection | awk 'NR==3')
   # TODO improve, highly dependent on test files we have, but in a hurry for now.
-  run [ $count -eq 250 ]
+  run [ $count -eq 300 ]
   echo "output = ${output}"
   [ "$status" -eq 0 ]
 }

--- a/tests/random-data-set.bats
+++ b/tests/random-data-set.bats
@@ -212,21 +212,21 @@
 }
 
 @test "Marker genes: Add second dataset for deletion tests and do cell clusters" {
-  cp -r $testsDir/marker-genes $SCRATCH_DIR/marker_genes
+  cp -r $testsDir/marker-genes $SCRATCH_DIR/marker-genes
 
   export EXP_ID=TEST-EXP2
   export EXPERIMENT_MGENES_PATH=$SCRATCH_DIR/marker-genes
   export EXPERIMENT_CLUSTERS_FILE=$SCRATCH_DIR/marker-genes/TEST-EXP2.clusters.tsv
   run load_db_scxa_cell_clusters.sh
-  
+
   echo "output = ${output}"
   [ "$status" -eq 0 ]
 }
 
 @test "Marker genes: Marker genes for second dataset for deletion tests" {
   export EXP_ID=TEST-EXP2
-  export EXPERIMENT_MGENES_PATH=$SCRATCH_DIR/marker_genes
-  export EXPERIMENT_CLUSTERS_FILE=$SCRATCH_DIR/marker_genes/TEST-EXP2.clusters.tsv
+  export EXPERIMENT_MGENES_PATH=$SCRATCH_DIR/marker-genes
+  export EXPERIMENT_CLUSTERS_FILE=$SCRATCH_DIR/marker-genes/TEST-EXP2.clusters.tsv
 
   run load_db_scxa_marker_genes.sh
   echo "output = ${output}"

--- a/tests/random-data-set.bats
+++ b/tests/random-data-set.bats
@@ -212,11 +212,13 @@
 }
 
 @test "Marker genes: Add second dataset for deletion tests" {
-  cp $testsDir/marker-genes/TEST-EXP1.clusters.tsv $testsDir/marker-genes/TEST-EXP2.clusters.tsv
-  cp $testsDir/marker-genes/TEST-EXP1.marker_genes_9.tsv $testsDir/marker-genes/TEST-EXP2.marker_genes_9.tsv
-  cp $testsDir/marker-genes/TEST-EXP1.marker_genes_10.tsv $testsDir/marker-genes/TEST-EXP2.marker_genes_10.tsv
-  cp $testsDir/marker-genes/TEST-EXP1.marker_genes_11.tsv $testsDir/marker-genes/TEST-EXP2.marker_genes_11.tsv
+  cp $testsDir/marker-genes/TEST-EXP1.clusters.tsv $SCRATCH_DIR/TEST-EXP2.clusters.tsv
+  cp $testsDir/marker-genes/TEST-EXP1.marker_genes_9.tsv $SCRATCH_DIR/TEST-EXP2.marker_genes_9.tsv
+  cp $testsDir/marker-genes/TEST-EXP1.marker_genes_10.tsv $SCRATCH_DIR/TEST-EXP2.marker_genes_10.tsv
+  cp $testsDir/marker-genes/TEST-EXP1.marker_genes_11.tsv $SCRATCH_DIR/TEST-EXP2.marker_genes_11.tsv
   export EXP_ID=TEST-EXP2
+  export EXPERIMENT_MGENES_PATH=$SCRATCH_DIR
+  export EXPERIMENT_CLUSTERS_FILE=$SCRATCH_DIR/TEST-EXP2.clusters.tsv
   run load_db_scxa_cell_clusters.sh
   run load_db_scxa_marker_genes.sh
   echo "output = ${output}"

--- a/tests/random-data-set.bats
+++ b/tests/random-data-set.bats
@@ -272,7 +272,41 @@
   [ "$status" -eq 0 ]
 }
 
-@test "TSNE and UMAP: Check that load_db_scxa_dimred.sh is in the path" {
+@test "Coords: Load tSNE data" {
+  export EXP_ID=TEST-EXP1
+  run load_db_scxa_dimred.sh
+  echo "output = ${output}"
+  [ "$status" -eq 0 ]
+}
+
+@test "Dimred parameters: check that JSON queries run and return expected values" {
+    target_perps="1 5 10 15 20  "
+    perps=$(echo "select distinct parameterisation->0->'perplexity' as perplexity from scxa_coords order by perplexity" | psql -At $dbConnection | tr '\n' ' ')
+    run [ "$perps" = "$target_perps" ]
+}
+
+@test "Coords: Check number of loaded rows" {
+  # Get third line with count of total entries in the database after our load
+  count=$(echo "SELECT COUNT(*) FROM scxa_coords" | psql -v ON_ERROR_STOP=1 $dbConnection | awk 'NR==3')
+  # TODO improve, highly dependent on test files we have, but in a hurry for now.
+  run [ $count -eq 250 ]
+  echo "output = ${output}"
+  [ "$status" -eq 0 ]
+}
+
+@test "Coords: Delete experiment" {
+  export EXP_ID=TEST-EXP1
+  run delete_db_scxa_dimred.sh
+  echo "output = ${output}"
+  [ "$status" -eq 0 ]
+  count=$(echo "SELECT COUNT(*) FROM scxa_coords WHERE experiment_accession = '"$EXP_ID"'" | psql -v ON_ERROR_STOP=1 $dbConnection | awk 'NR==3')
+  # TODO improve, highly dependent on test files we have, but in a hurry for now.
+  run [ $count -eq 0 ]
+  echo "output = ${output}"
+  [ "$status" -eq 0 ]
+}
+
+@test "Coords: Check that load_db_scxa_dimred.sh is in the path" {
   run which load_db_scxa_dimred.sh
   echo "output = ${output}"
   [ "$status" -eq 0 ]

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -14,6 +14,9 @@ flyway migrate -url=jdbc:postgresql://${HOST}:5432/${DB} -user=${USER} -password
 create-test-matrix-market-files.R TEST-EXP1
 create-test-matrix-market-files.R TEST-EXP2
 
+# For use within micromamba container
+export SCRATCH_DIR=/tmp
+
 export EXPERIMENT_MATRICES_PATH=$PWD
 
 # For marker genes loading testing


### PR DESCRIPTION
This updates tests to changes in schema versions, most notably the addition of scxa_coords and removal of tsne tables.

This also switches the testing to use a base container created the miniconda template approach, which happens to use a user different from root, which has some privs implications.