### PR TITLE
increased parameterisation for coordinate loading (anndata-associated)

### DIFF
--- a/bin/delete_db_scxa_dimred.sh
+++ b/bin/delete_db_scxa_dimred.sh
@@ -6,5 +6,5 @@ set -e
 dbConnection=${dbConnection:-$1}
 EXP_ID=${EXP_ID:-$2}
 
-echo "DELETE FROM scxa_coords WHERE experiment_accession = '"$EXP_ID"'" | \
+echo "DELETE FROM scxa_dimension_reduction WHERE experiment_accession = '"$EXP_ID"'" | \
   psql -v ON_ERROR_STOP=1 $dbConnection

--- a/bin/load_db_scxa_dimred.sh
+++ b/bin/load_db_scxa_dimred.sh
@@ -43,15 +43,18 @@ echo "DELETE FROM scxa_coords WHERE experiment_accession = '"$EXP_ID"'" | \
 
 for dimred_type in tsne umap; do
   dimred_prefix=$TSNE_PREFIX
+  dimred_type_name='t-SNE'
   dimred_param=perplexity
+
   if [ "$dimred_type" = 'umap' ]; then
     dimred_prefix=$UMAP_PREFIX
     dimred_param=n_neighbors
+    dimred_type_name='UMAP'
   fi  
 
   for f in $(ls $EXPERIMENT_DIMRED_PATH/$dimred_prefix*$DIMRED_SUFFIX); do
     paramval=$(echo $f | sed s+$EXPERIMENT_DIMRED_PATH/$dimred_prefix++ | sed s/$DIMRED_SUFFIX// )
-    tail -n +2 $f | awk -F'\t' -v EXP_ID="$EXP_ID" -v params="[{\"$dimred_param\": $paramval}]" -v method="$dimred_type" 'BEGIN { OFS = ","; }
+    tail -n +2 $f | awk -F'\t' -v EXP_ID="$EXP_ID" -v params="[{\"$dimred_param\": $paramval}]" -v method="$dimred_type_name" 'BEGIN { OFS = ","; }
     { print EXP_ID, method, $1, $2, $3, params }' >> $SCRATCH_DIR/dimredDataToLoad.csv
   done
 done

--- a/bin/load_db_scxa_dimred.sh
+++ b/bin/load_db_scxa_dimred.sh
@@ -41,7 +41,7 @@ echo "INSERT INTO scxa_dimension_reduction (experiment_accession, method, parame
 drid=$(echo "SELECT id FROM scxa_dimension_reduction WHERE experiment_accession = '$EXP_ID' AND method = '$DIMRED_TYPE' AND parameterisation = '$DIMRED_PARAM_JSON';" | psql -qtAX -v ON_ERROR_STOP=1 $dbConnection)
 
 # Transform the TSV coords into the DB table structure
-tail -n +2 $DIMRED_FILE_PATH | awk -F'\t' -v drid="$drid" -v params="$DIMRED_PARAM_JSON" -v method="$DIMRED_TYPE" 'BEGIN { OFS = ","; }
+tail -n +2 $DIMRED_FILE_PATH | awk -F'\t' -v drid="$drid" 'BEGIN { OFS = ","; }
 { print drid, $1, $2, $3 }' >> $SCRATCH_DIR/dimredDataToLoad.csv
 
 # Load data

--- a/bin/load_db_scxa_dimred.sh
+++ b/bin/load_db_scxa_dimred.sh
@@ -15,6 +15,7 @@ EXP_ID=${EXP_ID:-$2}
 DIMRED_TYPE=${DIMRED_TYPE:-$3}
 DIMRED_FILE_PATH=${DIMRED_FILE_PATH:-$4}
 DIMRED_PARAM_JSON=${DIMRED_PARAM_JSON:-$5}
+SCRATCH_DIR=${SCRATCH_DIR:-"$(dirname ${DIMRED_FILE_PATH})"}
 
 # Check that necessary environment variables are defined.
 [ -n ${dbConnection+x} ] || (echo "Env var dbConnection for the database connection needs to be defined. This includes the database name." && exit 1)

--- a/bin/load_db_scxa_dimred.sh
+++ b/bin/load_db_scxa_dimred.sh
@@ -36,13 +36,9 @@ checkDatabaseConnection $dbConnection
 echo "Dimension reductions: Loading data for $EXP_ID (new layout)..."
 rm -f $SCRATCH_DIR/dimredDataToLoad.csv
 
-# Delete table content for current EXP_ID
-echo "coords table: Delete rows for $EXP_ID:"
-echo "DELETE FROM scxa_coords WHERE experiment_accession = '"$EXP_ID"'" | \
-  psql -v ON_ERROR_STOP=1 $dbConnection
 
 # Transform the TSV coords into the DB table structure
-tail -n +2 $f | awk -F'\t' -v EXP_ID="$EXP_ID" -v params="$DIMRED_PARAM_JSON" -v method="$DIMRED_TYPE" 'BEGIN { OFS = ","; }
+tail -n +2 $DIMRED_FILE_PATH | awk -F'\t' -v EXP_ID="$EXP_ID" -v params="$DIMRED_PARAM_JSON" -v method="$DIMRED_TYPE" 'BEGIN { OFS = ","; }
 { print EXP_ID, method, $1, $2, $3, params }' >> $SCRATCH_DIR/dimredDataToLoad.csv
 
 # Load data

--- a/bin/load_db_scxa_dimred.sh
+++ b/bin/load_db_scxa_dimred.sh
@@ -38,7 +38,7 @@ rm -f $SCRATCH_DIR/dimredDataToLoad.csv
 
 # Insert a new row into the dimension reductions table
 echo "INSERT INTO scxa_dimension_reduction (experiment_accession, method, parameterisation) VALUES ('$EXP_ID', '$DIMRED_TYPE', '$DIMRED_PARAM_JSON');" | psql -v ON_ERROR_STOP=1 $dbConnection
-drid=$(echo "SELECT id FROM scxa_dimension_reduction WHERE experiment_access = '$EXP_ID' AND method = '$DIMRED_TYPE' AND parameterisation = '$DIMRED_PARAM_JSON';")
+drid=$(echo "SELECT id FROM scxa_dimension_reduction WHERE experiment_accession = '$EXP_ID' AND method = '$DIMRED_TYPE' AND parameterisation = '$DIMRED_PARAM_JSON';" | psql -qtAX -v ON_ERROR_STOP=1 $dbConnection)
 
 # Transform the TSV coords into the DB table structure
 tail -n +2 $DIMRED_FILE_PATH | awk -F'\t' -v drid="$drid" -v params="$DIMRED_PARAM_JSON" -v method="$DIMRED_TYPE" 'BEGIN { OFS = ","; }
@@ -58,7 +58,7 @@ rm $SCRATCH_DIR/dimredDataToLoad.csv
 # Roll back if unsucessful
 
 if [ $s -ne 0 ]; then
-  echo "DELETE FROM scxa_coords WHERE experiment_accession = '"$EXP_ID"' and method = 'tsne'" | \
+  echo "DELETE FROM scxa_dimension_reduction WHERE experiment_accession = '"$EXP_ID"' and method = '$DIMRED_TYPE' and parameterisation = '$DIMRED_PARAM_JSON'" | \
     psql -v ON_ERROR_STOP=1 $dbConnection
   exit 1
 fi

--- a/bin/load_db_scxa_marker_genes.sh
+++ b/bin/load_db_scxa_marker_genes.sh
@@ -214,7 +214,7 @@ if [[ -z ${NUMBER_MGENES_FILES+x} || $NUMBER_MGENES_FILES -gt 0 ]]; then
       $groupIds \
       <(join -t '|' \
         $groupIds \
-        <(tail -n +2 "${cellgroupMarkerStats}" | sed 's/, /REALCOMMA/g' | sed s/\"//g | sed s/,/\|/g | sed 's/REALCOMMA/, /g' |awk -F'|' -v EXP_ID="$EXP_ID" 'BEGIN { OFS = "|"; } {gsub("^None$","Not available",$3); gsub("^None$","Not available",$4); print EXP_ID"_"$2"_"$4,EXP_ID"_"$2"_"$3,$1,$2,$3,$4,$6,$7 }' | sort -t'|' -k 1,1) | \
+        <(tail -n +2 "${cellgroupMarkerStats}" | sed 's/, /REALCOMMA/g' | sed s/\"//g | sed s/,/\|/g | sed 's/REALCOMMA/, /g' |awk -F'|' -v EXP_ID="$EXP_ID" 'BEGIN { OFS = "|"; } {gsub("_", " ", $2); gsub("^None$","Not available",$3); gsub("^None$","Not available",$4); print EXP_ID"_"$2"_"$4,EXP_ID"_"$2"_"$3,$1,$2,$3,$4,$6,$7 }' | sort -t'|' -k 1,1) | \
         awk -F'|' 'BEGIN { OFS = "|"; } { print $3,$2,$4,$5,$6,$7,$8,$9 }' | sort -t'|' -k 1,1
       ) | awk -F'|' 'BEGIN { OFS = "|"; } { print $4"_"$2,$3,$2,$4,$5,$6,$7,$8,$9 }' | sort -t'|' -k 1,1 > $groupMarkerStatsWithIDs
 

--- a/tests/random-data-set.bats
+++ b/tests/random-data-set.bats
@@ -313,7 +313,25 @@
 
 @test "Coords: Load tSNE data" {
   export EXP_ID=TEST-EXP1
-  run load_db_scxa_dimred.sh
+
+  ls ${EXPERIMENT_DIMRED_PATH}/${EXP_ID}.tsne*.tsv | while read -r l; do
+    export DIMRED_TYPE=tsne
+    export DIMRED_FILE_PATH=$l
+    paramval=NUMBER=$(echo "$l" | sed 's/.*[^0-9]\([0-9]*\).tsv/\1/g')
+    export DIMRED_PARAM_JSON="[{\"perplexity\": $paramval}]"
+
+    run load_db_scxa_dimred.sh
+  done
+  
+  ls ${EXPERIMENT_DIMRED_PATH}/${EXP_ID}.umap*.tsv | while read -r l; do
+    export DIMRED_TYPE=umap
+    export DIMRED_FILE_PATH=$l
+    paramval=NUMBER=$(echo "$l" | sed 's/.*[^0-9]\([0-9]*\).tsv/\1/g')
+    export DIMRED_PARAM_JSON="[{\"n_neighbors\": $paramval}]"
+
+    run load_db_scxa_dimred.sh
+  done
+  
   echo "output = ${output}"
   [ "$status" -eq 0 ]
 }

--- a/tests/random-data-set.bats
+++ b/tests/random-data-set.bats
@@ -318,7 +318,6 @@
     export DIMRED_FILE_PATH=$l
     paramval=$(echo "$l" | sed 's/.*[^0-9]\([0-9]*\).tsv/\1/g')
     export DIMRED_PARAM_JSON="[{\"perplexity\": $paramval}]"
-
     echo run load_db_scxa_dimred.sh
   done
   ls ${EXPERIMENT_DIMRED_PATH}/${EXP_ID}.umap*.tsv | while read -r l; do
@@ -326,7 +325,6 @@
     export DIMRED_FILE_PATH=$l
     paramval=$(echo "$l" | sed 's/.*[^0-9]\([0-9]*\).tsv/\1/g')
     export DIMRED_PARAM_JSON="[{\"n_neighbors\": $paramval}]"
-
     run load_db_scxa_dimred.sh
   done
   echo "output = ${output}"

--- a/tests/random-data-set.bats
+++ b/tests/random-data-set.bats
@@ -313,25 +313,22 @@
 
 @test "Coords: Load tSNE data" {
   export EXP_ID=TEST-EXP1
-
   ls ${EXPERIMENT_DIMRED_PATH}/${EXP_ID}.tsne*.tsv | while read -r l; do
     export DIMRED_TYPE=tsne
     export DIMRED_FILE_PATH=$l
-    paramval=NUMBER=$(echo "$l" | sed 's/.*[^0-9]\([0-9]*\).tsv/\1/g')
+    paramval=$(echo "$l" | sed 's/.*[^0-9]\([0-9]*\).tsv/\1/g')
     export DIMRED_PARAM_JSON="[{\"perplexity\": $paramval}]"
 
-    run load_db_scxa_dimred.sh
+    echo run load_db_scxa_dimred.sh
   done
-  
   ls ${EXPERIMENT_DIMRED_PATH}/${EXP_ID}.umap*.tsv | while read -r l; do
     export DIMRED_TYPE=umap
     export DIMRED_FILE_PATH=$l
-    paramval=NUMBER=$(echo "$l" | sed 's/.*[^0-9]\([0-9]*\).tsv/\1/g')
+    paramval=$(echo "$l" | sed 's/.*[^0-9]\([0-9]*\).tsv/\1/g')
     export DIMRED_PARAM_JSON="[{\"n_neighbors\": $paramval}]"
 
     run load_db_scxa_dimred.sh
   done
-  
   echo "output = ${output}"
   [ "$status" -eq 0 ]
 }

--- a/tests/random-data-set.bats
+++ b/tests/random-data-set.bats
@@ -311,6 +311,12 @@
   [ "$status" -eq 0 ]
 }
 
+@test "Coords: Check that load_db_scxa_dimred.sh is in the path" {
+  run which load_db_scxa_dimred.sh
+  echo "output = ${output}"
+  [ "$status" -eq 0 ]
+}
+
 @test "Coords: Load tSNE data" {
   export EXP_ID=TEST-EXP1
   run $testsDir/test_dimred_load.sh
@@ -326,11 +332,13 @@
 }
 
 @test "Coords: Check number of loaded rows" {
+  export EXP_ID=TEST-EXP1
   # Get third line with count of total entries in the database after our load
-  count=$(echo "SELECT COUNT(*) FROM scxa_coords" | psql -v ON_ERROR_STOP=1 $dbConnection | awk 'NR==3')
+  count=$(echo "SELECT COUNT(*) FROM scxa_dimension_reduction d, scxa_coords c WHERE d.id = c.dimension_reduction_id and d.experiment_accession = '$EXP_ID'" | psql -qtAX -v ON_ERROR_STOP=1 $dbConnection)
   # TODO improve, highly dependent on test files we have, but in a hurry for now.
   run [ $count -eq 300 ]
   echo "output = ${output}"
+  echo "count = ${count}"
   [ "$status" -eq 0 ]
 }
 
@@ -339,15 +347,9 @@
   run delete_db_scxa_dimred.sh
   echo "output = ${output}"
   [ "$status" -eq 0 ]
-  count=$(echo "SELECT COUNT(*) FROM scxa_coords WHERE experiment_accession = '"$EXP_ID"'" | psql -v ON_ERROR_STOP=1 $dbConnection | awk 'NR==3')
+  count=$(echo "SELECT COUNT(*) FROM scxa_dimension_reduction d, scxa_coords c WHERE d.id = c.dimension_reduction_id and d.experiment_accession = '$EXP_ID'" | psql -qtAX -v ON_ERROR_STOP=1 $dbConnection)
   # TODO improve, highly dependent on test files we have, but in a hurry for now.
   run [ $count -eq 0 ]
-  echo "output = ${output}"
-  [ "$status" -eq 0 ]
-}
-
-@test "Coords: Check that load_db_scxa_dimred.sh is in the path" {
-  run which load_db_scxa_dimred.sh
   echo "output = ${output}"
   [ "$status" -eq 0 ]
 }

--- a/tests/random-data-set.bats
+++ b/tests/random-data-set.bats
@@ -313,20 +313,8 @@
 
 @test "Coords: Load tSNE data" {
   export EXP_ID=TEST-EXP1
-  ls ${EXPERIMENT_DIMRED_PATH}/${EXP_ID}.tsne*.tsv | while read -r l; do
-    export DIMRED_TYPE=tsne
-    export DIMRED_FILE_PATH=$l
-    paramval=$(echo "$l" | sed 's/.*[^0-9]\([0-9]*\).tsv/\1/g')
-    export DIMRED_PARAM_JSON="[{\"perplexity\": $paramval}]"
-    echo run load_db_scxa_dimred.sh
-  done
-  ls ${EXPERIMENT_DIMRED_PATH}/${EXP_ID}.umap*.tsv | while read -r l; do
-    export DIMRED_TYPE=umap
-    export DIMRED_FILE_PATH=$l
-    paramval=$(echo "$l" | sed 's/.*[^0-9]\([0-9]*\).tsv/\1/g')
-    export DIMRED_PARAM_JSON="[{\"n_neighbors\": $paramval}]"
-    run load_db_scxa_dimred.sh
-  done
+  run $testsDir/test_dimred_load.sh
+
   echo "output = ${output}"
   [ "$status" -eq 0 ]
 }

--- a/tests/test_dimred_load.sh
+++ b/tests/test_dimred_load.sh
@@ -8,12 +8,12 @@ ls ${EXPERIMENT_DIMRED_PATH}/${EXP_ID}.tsne*.tsv | while read -r l; do
   export DIMRED_FILE_PATH=$l
   paramval=$(echo "$l" | sed 's/.*[^0-9]\([0-9]*\).tsv/\1/g')
   export DIMRED_PARAM_JSON="[{\"perplexity\": $paramval}]"
-  run load_db_scxa_dimred.sh
+  load_db_scxa_dimred.sh
 done
 ls ${EXPERIMENT_DIMRED_PATH}/${EXP_ID}.umap*.tsv | while read -r l; do
   export DIMRED_TYPE=umap
   export DIMRED_FILE_PATH=$l
   paramval=$(echo "$l" | sed 's/.*[^0-9]\([0-9]*\).tsv/\1/g')
   export DIMRED_PARAM_JSON="[{\"n_neighbors\": $paramval}]"
-  run load_db_scxa_dimred.sh
+  load_db_scxa_dimred.sh
 done

--- a/tests/test_dimred_load.sh
+++ b/tests/test_dimred_load.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 
-# Delete table content for current EXP_ID
-echo "coords table: Delete rows for $EXP_ID:"
-echo "DELETE FROM scxa_coords WHERE experiment_accession = '"$EXP_ID"'" | \
-  psql -v ON_ERROR_STOP=1 $dbConnection
+delete_db_scxa_dimred.sh 
 
 # Normally we won't be extracting parameter values from file names, but we'll
 # do it just for testing
@@ -12,13 +9,14 @@ ls ${EXPERIMENT_DIMRED_PATH}/${EXP_ID}.tsne*.tsv | while read -r l; do
   export DIMRED_TYPE=tsne
   export DIMRED_FILE_PATH=$l
   paramval=$(echo "$l" | sed 's/.*[^0-9]\([0-9]*\).tsv/\1/g')
-  export DIMRED_PARAM_JSON="[{\"perplexity\": $paramval}]"
+  export DIMRED_PARAM_JSON='[{"perplexity": '$paramval'}]'
   load_db_scxa_dimred.sh
 done
+
 ls ${EXPERIMENT_DIMRED_PATH}/${EXP_ID}.umap*.tsv | while read -r l; do
   export DIMRED_TYPE=umap
   export DIMRED_FILE_PATH=$l
   paramval=$(echo "$l" | sed 's/.*[^0-9]\([0-9]*\).tsv/\1/g')
-  export DIMRED_PARAM_JSON="[{\"n_neighbors\": $paramval}]"
+  export DIMRED_PARAM_JSON='[{"n_neighbors": '$paramval'}]'
   load_db_scxa_dimred.sh
 done

--- a/tests/test_dimred_load.sh
+++ b/tests/test_dimred_load.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Normally we won't be extracting parameter values from file names, but we'll
+# do it just for testing
+
+ls ${EXPERIMENT_DIMRED_PATH}/${EXP_ID}.tsne*.tsv | while read -r l; do
+  export DIMRED_TYPE=tsne
+  export DIMRED_FILE_PATH=$l
+  paramval=$(echo "$l" | sed 's/.*[^0-9]\([0-9]*\).tsv/\1/g')
+  export DIMRED_PARAM_JSON="[{\"perplexity\": $paramval}]"
+  run load_db_scxa_dimred.sh
+done
+ls ${EXPERIMENT_DIMRED_PATH}/${EXP_ID}.umap*.tsv | while read -r l; do
+  export DIMRED_TYPE=umap
+  export DIMRED_FILE_PATH=$l
+  paramval=$(echo "$l" | sed 's/.*[^0-9]\([0-9]*\).tsv/\1/g')
+  export DIMRED_PARAM_JSON="[{\"n_neighbors\": $paramval}]"
+  run load_db_scxa_dimred.sh
+done

--- a/tests/test_dimred_load.sh
+++ b/tests/test_dimred_load.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Delete table content for current EXP_ID
+echo "coords table: Delete rows for $EXP_ID:"
+echo "DELETE FROM scxa_coords WHERE experiment_accession = '"$EXP_ID"'" | \
+  psql -v ON_ERROR_STOP=1 $dbConnection
+
 # Normally we won't be extracting parameter values from file names, but we'll
 # do it just for testing
 


### PR DESCRIPTION
This PR changes the coordinates loading script, such that:

 - Only a single dimension reduction is loaded at a time
 - Dimred type, parameterisation can be supplied directly via an environment variable.
 - A new schema version (see https://github.com/ebi-gene-expression-group/atlas-schemas/pull/27) is used, which factors out information common to a whole dimension reduction (type, parameterisation etc), rather than duplicating across all coordinates.

Essentially we will defer to the loading script in atlas-prod, which has access to the analysis bundle manifest, from which it can derive parameters etc. 