### PR TITLE
[Bugfix] Fix scratch dir value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Single Cell Expression Atlas database loading module (v1.0.0)
+# Single Cell Expression Atlas database loading module (v2.0.0)
 
 A [Single Cell Expression Atlas](https://www.ebi.ac.uk/gxa/sc) module for loading experiments to a Postgres 11 
 database. Release v0.4.0 was used for [the October 2022 data release of Single Cell Expression 
@@ -63,7 +63,7 @@ export dbConnection=...
 delete_db_scxa_dimred.sh
 ```
 
-## `scxa_cell_group` and `scxa_cell_group_membership` table
+## `scxa_cell_group` and `scxa_cell_group_membership` tables
 
 ### Load data
 Run `bin/load_db_scxa_cell_clusters.sh`. It requires the following environment variables:
@@ -115,6 +115,25 @@ export EXP_ID=...
 export dbConnection=...
 
 delete_db_scxa_marker_genes.sh
+```
+
+## `exp_design` and `exp_design_column` tables
+
+### Load data
+Run `bin/load_exp_design.sh`. It requires the following environment variables:
+
+| Variable name         | Description                                                                                                                                                                                                                                  |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `CONDENSED_SDRF_FILE` | Path of the condensed SDRF file of the experiment being loaded                                                                                                                                                                               |
+| `SDRF_FILE`           | Path of the SDRF file of the experiment being loaded                                                                                                                                                                                      |
+| `dbConnection`        | A Postgres connection string in the form `postgresql://{user}:{password}@{host:port}/{databaseName}` pointing to a Postgres 11 server where the expected `scxa_cell_group_marker_genes` and `scxa_cell_group_marker_gene_stats` tables exist |
+
+### Delete data
+Currently, there’s no script to delete data from these tables. You can do it manually with the following SQL statements:
+
+```sql
+DELETE FROM exp_design WHERE exp_design_column_id IN (SELECT id FROM exp_design_column WHERE experiment_accession='E-FOO-123');
+DELETE FROM exp_design_column WHERE experiment_accession='E-FOO-123';
 ```
 
 ## Post-loading a batch of experiments

--- a/bin/load_db_scxa_dimred.sh
+++ b/bin/load_db_scxa_dimred.sh
@@ -13,7 +13,7 @@ EXP_ID=${EXP_ID:-$2}
 DIMRED_TYPE=${DIMRED_TYPE:-$3}
 DIMRED_FILE_PATH=${DIMRED_FILE_PATH:-$4}
 DIMRED_PARAM_JSON=${DIMRED_PARAM_JSON:-$5}
-SCRATCH_DIR=${SCRATCH_DIR:-"$DIMRED_FILE_PATH"}
+SCRATCH_DIR=${SCRATCH_DIR:-"$(dirname ${DIMRED_FILE_PATH})"}
 
 # Check that necessary environment variables are defined.
 [ -n ${dbConnection+x} ] || (echo "Env var dbConnection for the database connection needs to be defined. This includes the database name." && exit 1)


### PR DESCRIPTION
Before this change when `SCRATCH_DIR` variable was not defined as an environmental variable it got its value from the `DIMRED_FILE_PATH` that also contained the filename. 
In the README the `DIMRED_FILE_PATH` is defined: TSV file with the coordinates. We only need the path of the directory, so that is why I added this change.