### PR TITLE
Fill priority column in table `scxa_dimension_reduction` (related to SCXA migration V19)

### DIFF
--- a/bin/load_db_scxa_dimred.sh
+++ b/bin/load_db_scxa_dimred.sh
@@ -37,6 +37,9 @@ rm -f $SCRATCH_DIR/dimredDataToLoad.csv
 # Insert a new row into the dimension reductions table
 echo "INSERT INTO scxa_dimension_reduction (experiment_accession, method, parameterisation) VALUES ('$EXP_ID', '$DIMRED_TYPE', '$DIMRED_PARAM_JSON');" | psql -v ON_ERROR_STOP=1 $dbConnection
 drid=$(echo "SELECT id FROM scxa_dimension_reduction WHERE experiment_accession = '$EXP_ID' AND method = '$DIMRED_TYPE' AND parameterisation = '$DIMRED_PARAM_JSON';" | psql -qtAX -v ON_ERROR_STOP=1 $dbConnection)
+# we should fill 'priority' here too
+
+# bonus if we check there is only one non-zero value in the table
 
 # Transform the TSV coords into the DB table structure
 tail -n +2 $DIMRED_FILE_PATH | awk -F'\t' -v drid="$drid" 'BEGIN { OFS = ","; }


### PR DESCRIPTION
This relates to the new `priority` field on the table [scxa_dimension_reduction](https://github.com/ebi-gene-expression-group/atlas-schemas/blob/master/flyway/scxa/migrations/V19__anndata_import_changes.sql#L3) added in the migration V19, which is the current one in staging. 

@ke4 @upendrakumbham @pmb59 have continued [previous discussions](https://github.com/ebi-gene-expression-group/atlas-schemas/pull/27) and agreed possible best way forward is leave all priorities as 0 (default) and only one as non-zero, which will be the dimension reduction first picked by the UI.  If all values are zero, then current policy applies. See issue in [atlas-web-single-cell](https://github.com/ebi-gene-expression-group/atlas-web-single-cell/issues/374).

Possibly we could make this values boolean (TRUE/FALSE) or leave numeric to [allow flexibility for future implementations](https://github.com/ebi-gene-expression-group/atlas-schemas/pull/27).

Data Production Team is responsible of calculating the priority values, and  adding them to the DB - this PR.







